### PR TITLE
Optimize import performance using numpy

### DIFF
--- a/panels/export_model.py
+++ b/panels/export_model.py
@@ -1,6 +1,6 @@
 import os
 import time
-from .import_model import get_color_scale, get_ssbh_lib_json_exe_path
+from .import_model import get_ssbh_lib_json_exe_path
 import bpy
 import os.path
 import numpy as np


### PR DESCRIPTION
This PR takes advantage of the new experimental numpy support for ssbh_data_py to optimize importing performance. Python lists add a lot of overhead compared to numpy arrays for a large number of elements since the elements of a Python list may have different types. Both Blender and ssbh_data_py take advantage of the memory representation of numpy arrays to optimize performance. Import times should continue to improve as ssbh_data_py continues to develop, but I wouldn't expect any new major speedups.

| Model | model.numshb | Import Model (old) | Import Model (new) | Speedup | 
| --- | --- | --- | --- | --- |
| mario c00 | 1.20 MB | 1.00 seconds | 0.291 seconds | 3.46x |
| gamewatch c00 | 24.5 MB | 6.488 seconds | 2.163 seconds | 2.99x |