### PR TITLE
Proper name for model.nuhlpb upon export.

### DIFF
--- a/panels/export_model.py
+++ b/panels/export_model.py
@@ -843,5 +843,5 @@ def create_and_save_nuhlpb(folder, armature:bpy.types.Object):
         nuhlpb_json['data']['Hlpb']['list1'].append(index)
         nuhlpb_json['data']['Hlpb']['list2'].append(1)
 
-    save_ssbh_json(nuhlpb_json, str(folder.joinpath('model.nuhlpb.tmp.json')))
+    save_ssbh_json(nuhlpb_json, str(folder.joinpath('model.nuhlpb')))
 


### PR DESCRIPTION
As of now, the model.nuhlpb file exported by the tool is named "model.nuhlpb.tmp.json", despite not being a json. While using this tool, I was confused by the lack of a generated nuhlpb until I realized that it was just naming it strangely.