### PR TITLE
Fixed re-enable error

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -63,6 +63,7 @@ def register():
 def unregister():
     print('Unloading Smash Ultimate Blender Tools')
 
+    shaders.custom_sampler_node.unregister()
     for cls in reversed(classes):
         try:
             bpy.utils.unregister_class(cls)


### PR DESCRIPTION
If you enabled, disabled, and then try to re-enable the addon, it throws an `already registered as a subclass` error.